### PR TITLE
Obsolete compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: "3.9"
+---
+
 services:
   api:
     build: .


### PR DESCRIPTION
Compose version is not needed anymore.

See [https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)

Bon courage Dan 🤣